### PR TITLE
chore: add plugin preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,7 @@ To reuse the lib preset just define your `.github/renovate.json` file as follows
 
 - `default`: Default preset for all Gravitee.io repositories.
 - `lib`: Base preset for Gravitee.io library repositories.
-- `policy`: Base preset for Gravitee.io policy repositories.
+- `plugin`: Base preset for any Gravitee.io plugin repositories (policy, reporter, endpoint, entrypoint...).
+- <del>`policy`: Base preset for Gravitee.io policy repositories.</del> Use `plugin` instead
+- <del>`reporter`: Base preset for Gravitee.io reporter repositories.</del> Use `plugin` instead
 - `federationagent`: Base preset for Gravitee.io Federation Agent repositories.

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,3 @@
+{
+    "extends": ["local>gravitee-io/renovate-config"]
+}

--- a/policy.json
+++ b/policy.json
@@ -1,3 +1,3 @@
 {
-    "extends": ["local>gravitee-io/renovate-config"]
+    "extends": ["local>gravitee-io/renovate-config:plugin"]
 }

--- a/reporter.json
+++ b/reporter.json
@@ -1,3 +1,3 @@
 {
-    "extends": ["local>gravitee-io/renovate-config"]
+    "extends": ["local>gravitee-io/renovate-config:plugin"]
 }


### PR DESCRIPTION
Add a plugin preset for plugin type repository (policy, reporter, endpoint...) This segregation matches what we define in the Gravitee orb, where we have 2 kinds of workflows: `lib` and `plugin`.